### PR TITLE
chore: migrate HawkEye to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
         with:
-          tool: typos-cli,taplo-cli,hawkeye
+          tool: typos-cli,taplo-cli,hawkeye@7.0.0
       - name: Check all
         run: |
           hawkeye check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
         with:
-          tool: typos-cli,taplo-cli,hawkeye@7.0.0
+          tool: typos-cli,taplo-cli,hawkeye
       - name: Check all
         run: |
           hawkeye check

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-headerPath = "Apache-2.0.txt"
+[header]
+builtin = "Apache-2.0"
 
+[files]
 includes = ['**/*.proto', '**/*.rs', '**/*.yml', '**/*.yaml', '**/*.toml']
 
-[properties]
-copyrightOwner = "FastLabs Developers"
-inceptionYear = 2024
+[props]
+copyright_owner = "FastLabs Developers"
+inception_year = 2024

--- a/src/format.rs
+++ b/src/format.rs
@@ -96,7 +96,11 @@ impl SyslogContext {
     }
 
     /// Format the Syslog message with the given severity as defined in RFC-3164.
-    pub fn format_rfc3164<M>(&self, severity: Severity, message: Option<M>) -> RFC3164Formatter<M> {
+    pub fn format_rfc3164<M>(
+        &self,
+        severity: Severity,
+        message: Option<M>,
+    ) -> RFC3164Formatter<'_, M> {
         RFC3164Formatter {
             context: self,
             severity,
@@ -111,7 +115,7 @@ impl SyslogContext {
         msgid: Option<S>,
         elements: Vec<SDElement>,
         message: Option<M>,
-    ) -> RFC5424Formatter<M>
+    ) -> RFC5424Formatter<'_, M>
     where
         S: Into<String>,
         M: fmt::Display,


### PR DESCRIPTION
## Summary

- migrate licenserc.toml to the HawkEye v7 schema
- install the latest HawkEye in CI
- make formatter lifetimes explicit for current nightly linting